### PR TITLE
Add ng-google-sheets-db lib.

### DIFF
--- a/src/app/shared/data/resources.data.ts
+++ b/src/app/shared/data/resources.data.ts
@@ -456,4 +456,11 @@ export const RESOURCES: Resource[] = [
     link: 'https://github.com/nilsmehlhorn/ngrx-wieder',
     type: 'lib',
   },
+  {
+    id: 78,
+    title: 'ng-google-sheets-db',
+    description: 'Use Google Sheets as your (read-only) backend!',
+    link: 'https://github.com/FranzDiebold/ng-google-sheets-db-library',
+    type: 'lib',
+  },
 ];


### PR DESCRIPTION
[ng-google-sheets-db](https://github.com/FranzDiebold/ng-google-sheets-db-library) is an Angular library to use Google Sheets as your (read-only) backend! 🚀
It is super simple to use!